### PR TITLE
Pass Evaluators to AST to function

### DIFF
--- a/src/doc.js
+++ b/src/doc.js
@@ -69,7 +69,7 @@ Doc.prototype.get_content = function(t,r){
     if(t == "xml") return (new XMLSerializer()).serializeToString(this.base);
     else if(t == "ast") return JSON.stringify(this.syntax_tree());
     else if(t == "text") return AST.to_text(this.syntax_tree());
-    else if(t == "function") return AST.to_function(this.syntax_tree());
+    else if(t == "function") return AST.to_function(this.syntax_tree(), r);
     else if(t == "eqns") return JSON.stringify(AST.to_eqlist(this.syntax_tree()));
     else return this.manual_render(t,this.root(),r);
 }


### PR DESCRIPTION
If you call .func({ ...some custom evaluators... }) without this change, it won't pass the custom evaluators to AST to_function, so they will remain "unimplimented". This is a simple fix