### PR TITLE
Allow OSK parent target to be optionally provided when attaching

### DIFF
--- a/src/osk.js
+++ b/src/osk.js
@@ -88,7 +88,7 @@ function make_tabs(tabbar, element){
 GuppyOSK.prototype.detach = function(guppy){
     if(this.element){
         if((!guppy && this.guppy) || this.guppy == guppy){
-            document.body.removeChild(this.element);
+            this.element.parentElement.removeChild(this.element);
             this.guppy = null;
             this.element = null;
         }
@@ -129,14 +129,16 @@ GuppyOSK.str_to_syms = function(s){
     Attach the keyboard to a Guppy instance and display it.
     @param {Guppy} [guppy] - The instance of Guppy to which the
     keyboard will attach.
+    @param {Element} [target] - Optional parent target element to
+    attach the OSK to.
     @memberof GuppyOSK
 */
-GuppyOSK.prototype.attach = function(guppy){
+GuppyOSK.prototype.attach = function(guppy, target){
     var self = this;
     var s = null;
     if(this.guppy == guppy) return;
     if(this.guppy){
-        document.body.removeChild(this.element);
+        this.element.parentElement.removeChild(this.element);
         this.element = null;
         this.guppy = null;
     }
@@ -275,7 +277,11 @@ GuppyOSK.prototype.attach = function(guppy){
     add_matrix_control("-row", function(e){ e.preventDefault();guppy.engine.list_remove_row();guppy.render();});
 
     osk.appendChild(controls);
-    document.body.appendChild(osk);
+    if (target) {
+        target.appendChild(osk);
+    } else {
+        document.body.appendChild(osk);
+    }
 
     this.guppy = guppy;
     this.element = osk;


### PR DESCRIPTION
Modifies `attach` and `detach` methods in GuppyOSK to allow providing
a DOM element to attach the OSK to (with the fallback default remaining
the document body). Gives the developer more control over page layout.