### PR TITLE
Don't allow operators to be consumed by symbols

### DIFF
--- a/build/guppy.js
+++ b/build/guppy.js
@@ -4177,99 +4177,99 @@ var Guppy = (function () {
     };
 
     var Keyboard = function Keyboard() {
-    			this.is_mouse_down = false;
+    				this.is_mouse_down = false;
 
-    			/* keyboard behaviour definitions */
+    				/* keyboard behaviour definitions */
 
-    			// keys aside from 0-9,a-z,A-Z
-    			this.k_chars = {
-    						"+": "+",
-    						"-": "-",
-    						"*": "*",
-    						".": "."
-    			};
-    			this.k_text = {
-    						"/": "/",
-    						"*": "*",
-    						"(": "(",
-    						")": ")",
-    						"<": "<",
-    						">": ">",
-    						"|": "|",
-    						"!": "!",
-    						",": ",",
-    						".": ".",
-    						";": ";",
-    						"=": "=",
-    						"[": "[",
-    						"]": "]",
-    						"@": "@",
-    						"'": "'",
-    						"`": "`",
-    						":": ":",
-    						"\"": "\"",
-    						"?": "?",
-    						"space": " "
-    			};
-    			this.k_controls = {
-    						"up": "up",
-    						"down": "down",
-    						"right": "right",
-    						"left": "left",
-    						"alt+k": "up",
-    						"alt+j": "down",
-    						"alt+l": "right",
-    						"alt+h": "left",
-    						"space": "spacebar",
-    						"home": "home",
-    						"end": "end",
-    						"backspace": "backspace",
-    						"del": "delete_key",
-    						"mod+a": "sel_all",
-    						"mod+c": "sel_copy",
-    						"mod+x": "sel_cut",
-    						"mod+v": "sel_paste",
-    						"mod+z": "undo",
-    						"mod+y": "redo",
-    						"enter": "done",
-    						"mod+shift+right": "list_extend_copy_right",
-    						"mod+shift+left": "list_extend_copy_left",
-    						",": "list_extend_right",
-    						";": "list_extend_down",
-    						"mod+right": "list_extend_right",
-    						"mod+left": "list_extend_left",
-    						"mod+up": "list_extend_up",
-    						"mod+down": "list_extend_down",
-    						"mod+shift+up": "list_extend_copy_up",
-    						"mod+shift+down": "list_extend_copy_down",
-    						"mod+backspace": "list_remove",
-    						"mod+shift+backspace": "list_remove_row",
-    						"shift+left": "sel_left",
-    						"shift+right": "sel_right",
-    						")": "right_paren",
-    						"\\": "backslash",
-    						"tab": "tab"
-    			};
+    				// keys aside from 0-9,a-z,A-Z
+    				this.k_chars = {
+    								"+": "+",
+    								"-": "-",
+    								"*": "*",
+    								".": "."
+    				};
+    				this.k_text = {
+    								"/": "/",
+    								"*": "*",
+    								"(": "(",
+    								")": ")",
+    								"<": "<",
+    								">": ">",
+    								"|": "|",
+    								"!": "!",
+    								",": ",",
+    								".": ".",
+    								";": ";",
+    								"=": "=",
+    								"[": "[",
+    								"]": "]",
+    								"@": "@",
+    								"'": "'",
+    								"`": "`",
+    								":": ":",
+    								"\"": "\"",
+    								"?": "?",
+    								"space": " "
+    				};
+    				this.k_controls = {
+    								"up": "up",
+    								"down": "down",
+    								"right": "right",
+    								"left": "left",
+    								"alt+k": "up",
+    								"alt+j": "down",
+    								"alt+l": "right",
+    								"alt+h": "left",
+    								"space": "spacebar",
+    								"home": "home",
+    								"end": "end",
+    								"backspace": "backspace",
+    								"del": "delete_key",
+    								"mod+a": "sel_all",
+    								"mod+c": "sel_copy",
+    								"mod+x": "sel_cut",
+    								"mod+v": "sel_paste",
+    								"mod+z": "undo",
+    								"mod+y": "redo",
+    								"enter": "done",
+    								"mod+shift+right": "list_extend_copy_right",
+    								"mod+shift+left": "list_extend_copy_left",
+    								",": "list_extend_right",
+    								";": "list_extend_down",
+    								"mod+right": "list_extend_right",
+    								"mod+left": "list_extend_left",
+    								"mod+up": "list_extend_up",
+    								"mod+down": "list_extend_down",
+    								"mod+shift+up": "list_extend_copy_up",
+    								"mod+shift+down": "list_extend_copy_down",
+    								"mod+backspace": "list_remove",
+    								"mod+shift+backspace": "list_remove_row",
+    								"shift+left": "sel_left",
+    								"shift+right": "sel_right",
+    								")": "right_paren",
+    								"\\": "backslash",
+    								"tab": "tab"
+    				};
 
-    			// Will populate keyboard shortcuts for symbols from symbol files
-    			this.k_syms = {};
+    				// Will populate keyboard shortcuts for symbols from symbol files
+    				this.k_syms = {};
 
-    			this.k_raw = "mod+space";
+    				this.k_raw = "mod+space";
 
-    			var i = 0;
+    				var i = 0;
 
-    			// letters
+    				// letters
 
-    			for (i = 65; i <= 90; i++) {
-    						this.k_chars[String.fromCharCode(i).toLowerCase()] = String.fromCharCode(i).toLowerCase();
-    						this.k_chars['shift+' + String.fromCharCode(i).toLowerCase()] = String.fromCharCode(i).toUpperCase();
-    			}
+    				for (i = 65; i <= 90; i++) {
+    								this.k_chars[String.fromCharCode(i).toLowerCase()] = String.fromCharCode(i).toLowerCase();
+    								this.k_chars['shift+' + String.fromCharCode(i).toLowerCase()] = String.fromCharCode(i).toUpperCase();
+    				}
 
-    			// numbers
+    				// numbers
 
-    			for (i = 48; i <= 57; i++) {
-    						this.k_chars[String.fromCharCode(i)] = String.fromCharCode(i);
-    			}
+    				for (i = 48; i <= 57; i++) {
+    								this.k_chars[String.fromCharCode(i)] = String.fromCharCode(i);
+    				}
     };
 
     var Settings = {};
@@ -4758,9 +4758,11 @@ var Guppy = (function () {
             } else if ("input" in s) {
                 // If we're at the beginning, then the token is the previous f node
                 if (this.caret == 0 && this.current.previousSibling != null) {
-                    content[cur] = [this.make_e(""), this.current.previousSibling, this.make_e("")];
-                    to_replace = this.current.previousSibling;
-                    replace_f = true;
+                    if (this.current.previousSibling.getAttribute("ast_type") != "operator") {
+                        content[cur] = [this.make_e(""), this.current.previousSibling, this.make_e("")];
+                        to_replace = this.current.previousSibling;
+                        replace_f = true;
+                    }
                 } else {
                     // look for [0-9.]+|[a-zA-Z] immediately preceeding the caret and use that as token
                     var prev = this.current.firstChild.nodeValue.substring(0, this.caret);

--- a/src/engine.js
+++ b/src/engine.js
@@ -354,7 +354,7 @@ Engine.prototype.insert_symbol = function(sym_name,sym_args){
         else if("input" in s){
             // If we're at the beginning, then the token is the previous f node
             if(this.caret == 0 && this.current.previousSibling != null){
-                if (this.current.previousSibling.getAttribute("ast_type") != "operator") {
+                if(this.current.previousSibling.getAttribute("ast_type") != "operator") {
                     content[cur] = [this.make_e(""), this.current.previousSibling, this.make_e("")];
                     to_replace = this.current.previousSibling;
                     replace_f = true;

--- a/src/engine.js
+++ b/src/engine.js
@@ -354,9 +354,11 @@ Engine.prototype.insert_symbol = function(sym_name,sym_args){
         else if("input" in s){
             // If we're at the beginning, then the token is the previous f node
             if(this.caret == 0 && this.current.previousSibling != null){
-                content[cur] = [this.make_e(""), this.current.previousSibling, this.make_e("")];
-                to_replace = this.current.previousSibling;
-                replace_f = true;
+                if (this.current.previousSibling.getAttribute("ast_type") != "operator") {
+                    content[cur] = [this.make_e(""), this.current.previousSibling, this.make_e("")];
+                    to_replace = this.current.previousSibling;
+                    replace_f = true;
+                }
             }
             else{
                 // look for [0-9.]+|[a-zA-Z] immediately preceeding the caret and use that as token


### PR DESCRIPTION
Before it was possbile to enter `=` press forward slash and get `\frac{=}{...}.` Now it checks to make sure that the symbol isn't an operator.