### PR TITLE
Improved syntax tree importing

### DIFF
--- a/build/guppy.js
+++ b/build/guppy.js
@@ -310,6 +310,12 @@ var Guppy = (function () {
     };
 
     AST.eval = function (ast, functions, parent) {
+        if (ast.length == 1 && ast[0] == "blank") {
+            var elem = document.implementation.createDocument(null, "c");
+            elem.documentElement.innerHTML = "<e></e>";
+            return elem;
+        }
+
         ans = null;
         if (!functions["_default"]) functions["_default"] = function (name, args) {
             throw Error("Function not implemented: " + name + "(" + args + ")");
@@ -3910,6 +3916,9 @@ var Guppy = (function () {
     };
 
     Doc.prototype.import_ast = function (ast, syms, s2n) {
+        if (typeof ast == "string") {
+            ast = JSON.parse(ast);
+        }
         syms = syms || Symbols.symbols;
         s2n = s2n || Symbols.symbol_to_node;
         var doc = AST.to_xml(ast, syms, s2n);
@@ -4177,99 +4186,99 @@ var Guppy = (function () {
     };
 
     var Keyboard = function Keyboard() {
-    			this.is_mouse_down = false;
+    				this.is_mouse_down = false;
 
-    			/* keyboard behaviour definitions */
+    				/* keyboard behaviour definitions */
 
-    			// keys aside from 0-9,a-z,A-Z
-    			this.k_chars = {
-    						"+": "+",
-    						"-": "-",
-    						"*": "*",
-    						".": "."
-    			};
-    			this.k_text = {
-    						"/": "/",
-    						"*": "*",
-    						"(": "(",
-    						")": ")",
-    						"<": "<",
-    						">": ">",
-    						"|": "|",
-    						"!": "!",
-    						",": ",",
-    						".": ".",
-    						";": ";",
-    						"=": "=",
-    						"[": "[",
-    						"]": "]",
-    						"@": "@",
-    						"'": "'",
-    						"`": "`",
-    						":": ":",
-    						"\"": "\"",
-    						"?": "?",
-    						"space": " "
-    			};
-    			this.k_controls = {
-    						"up": "up",
-    						"down": "down",
-    						"right": "right",
-    						"left": "left",
-    						"alt+k": "up",
-    						"alt+j": "down",
-    						"alt+l": "right",
-    						"alt+h": "left",
-    						"space": "spacebar",
-    						"home": "home",
-    						"end": "end",
-    						"backspace": "backspace",
-    						"del": "delete_key",
-    						"mod+a": "sel_all",
-    						"mod+c": "sel_copy",
-    						"mod+x": "sel_cut",
-    						"mod+v": "sel_paste",
-    						"mod+z": "undo",
-    						"mod+y": "redo",
-    						"enter": "done",
-    						"mod+shift+right": "list_extend_copy_right",
-    						"mod+shift+left": "list_extend_copy_left",
-    						",": "list_extend_right",
-    						";": "list_extend_down",
-    						"mod+right": "list_extend_right",
-    						"mod+left": "list_extend_left",
-    						"mod+up": "list_extend_up",
-    						"mod+down": "list_extend_down",
-    						"mod+shift+up": "list_extend_copy_up",
-    						"mod+shift+down": "list_extend_copy_down",
-    						"mod+backspace": "list_remove",
-    						"mod+shift+backspace": "list_remove_row",
-    						"shift+left": "sel_left",
-    						"shift+right": "sel_right",
-    						")": "right_paren",
-    						"\\": "backslash",
-    						"tab": "tab"
-    			};
+    				// keys aside from 0-9,a-z,A-Z
+    				this.k_chars = {
+    								"+": "+",
+    								"-": "-",
+    								"*": "*",
+    								".": "."
+    				};
+    				this.k_text = {
+    								"/": "/",
+    								"*": "*",
+    								"(": "(",
+    								")": ")",
+    								"<": "<",
+    								">": ">",
+    								"|": "|",
+    								"!": "!",
+    								",": ",",
+    								".": ".",
+    								";": ";",
+    								"=": "=",
+    								"[": "[",
+    								"]": "]",
+    								"@": "@",
+    								"'": "'",
+    								"`": "`",
+    								":": ":",
+    								"\"": "\"",
+    								"?": "?",
+    								"space": " "
+    				};
+    				this.k_controls = {
+    								"up": "up",
+    								"down": "down",
+    								"right": "right",
+    								"left": "left",
+    								"alt+k": "up",
+    								"alt+j": "down",
+    								"alt+l": "right",
+    								"alt+h": "left",
+    								"space": "spacebar",
+    								"home": "home",
+    								"end": "end",
+    								"backspace": "backspace",
+    								"del": "delete_key",
+    								"mod+a": "sel_all",
+    								"mod+c": "sel_copy",
+    								"mod+x": "sel_cut",
+    								"mod+v": "sel_paste",
+    								"mod+z": "undo",
+    								"mod+y": "redo",
+    								"enter": "done",
+    								"mod+shift+right": "list_extend_copy_right",
+    								"mod+shift+left": "list_extend_copy_left",
+    								",": "list_extend_right",
+    								";": "list_extend_down",
+    								"mod+right": "list_extend_right",
+    								"mod+left": "list_extend_left",
+    								"mod+up": "list_extend_up",
+    								"mod+down": "list_extend_down",
+    								"mod+shift+up": "list_extend_copy_up",
+    								"mod+shift+down": "list_extend_copy_down",
+    								"mod+backspace": "list_remove",
+    								"mod+shift+backspace": "list_remove_row",
+    								"shift+left": "sel_left",
+    								"shift+right": "sel_right",
+    								")": "right_paren",
+    								"\\": "backslash",
+    								"tab": "tab"
+    				};
 
-    			// Will populate keyboard shortcuts for symbols from symbol files
-    			this.k_syms = {};
+    				// Will populate keyboard shortcuts for symbols from symbol files
+    				this.k_syms = {};
 
-    			this.k_raw = "mod+space";
+    				this.k_raw = "mod+space";
 
-    			var i = 0;
+    				var i = 0;
 
-    			// letters
+    				// letters
 
-    			for (i = 65; i <= 90; i++) {
-    						this.k_chars[String.fromCharCode(i).toLowerCase()] = String.fromCharCode(i).toLowerCase();
-    						this.k_chars['shift+' + String.fromCharCode(i).toLowerCase()] = String.fromCharCode(i).toUpperCase();
-    			}
+    				for (i = 65; i <= 90; i++) {
+    								this.k_chars[String.fromCharCode(i).toLowerCase()] = String.fromCharCode(i).toLowerCase();
+    								this.k_chars['shift+' + String.fromCharCode(i).toLowerCase()] = String.fromCharCode(i).toUpperCase();
+    				}
 
-    			// numbers
+    				// numbers
 
-    			for (i = 48; i <= 57; i++) {
-    						this.k_chars[String.fromCharCode(i)] = String.fromCharCode(i);
-    			}
+    				for (i = 48; i <= 57; i++) {
+    								this.k_chars[String.fromCharCode(i)] = String.fromCharCode(i);
+    				}
     };
 
     var Settings = {};

--- a/build/guppy.js
+++ b/build/guppy.js
@@ -65,6 +65,9 @@ var Guppy = (function () {
         functions["_default"] = function (name, args) {
             return name + "(" + args.join(",") + ")";
         };
+        functions["blank"] = function () {
+            return "()";
+        };
         return AST.eval(ast, functions);
     };
 
@@ -195,6 +198,11 @@ var Guppy = (function () {
         functions["_default"] = function (name, args) {
             return make_sym(name, args);
         };
+        functions["blank"] = function () {
+            var elem = document.implementation.createDocument(null, "c");
+            elem.documentElement.innerHTML = "<e></e>";
+            return elem;
+        };
         var ans = AST.eval(ast, functions);
         var new_base = new window.DOMParser().parseFromString("<m></m>", "text/xml");
         for (var nn = ans.documentElement.firstChild; nn; nn = nn.nextSibling) {
@@ -311,9 +319,7 @@ var Guppy = (function () {
 
     AST.eval = function (ast, functions, parent) {
         if (ast.length == 1 && ast[0] == "blank") {
-            var elem = document.implementation.createDocument(null, "c");
-            elem.documentElement.innerHTML = "<e></e>";
-            return elem;
+            return functions["blank"]();
         }
 
         ans = null;

--- a/src/ast.js
+++ b/src/ast.js
@@ -26,6 +26,7 @@ AST.to_text = function(ast){
     functions["exponential"] = function(args){return "("+args[0]+"^"+args[1]+")";};
     functions["factorial"] = function(args){return "("+args[0]+")!";};
     functions["_default"] = function(name, args){return name + "(" + args.join(",") + ")";};
+    functions["blank"] = function(){return "()"};
     return AST.eval(ast, functions);
 }
 
@@ -152,6 +153,11 @@ AST.to_xml = function(ast, symbols, symbol_to_node){
     functions["_default"] = function(name, args){
         return make_sym(name, args);
     }
+    functions["blank"] = function(){
+        var elem = document.implementation.createDocument(null, "c");
+        elem.documentElement.innerHTML = "<e></e>";
+        return elem;
+    }
     var ans = AST.eval(ast, functions);
     var new_base = (new window.DOMParser()).parseFromString("<m></m>", "text/xml");
     for(var nn = ans.documentElement.firstChild; nn; nn = nn.nextSibling){
@@ -203,9 +209,7 @@ AST.to_function = function(ast, functions){
 
 AST.eval = function(ast, functions, parent){
     if(ast.length == 1 && ast[0] == "blank"){
-        var elem = document.implementation.createDocument(null, "c");
-        elem.documentElement.innerHTML = "<e></e>";
-        return elem;
+        return functions["blank"]();
     }
 
     ans = null;

--- a/src/ast.js
+++ b/src/ast.js
@@ -49,7 +49,7 @@ AST.to_xml = function(ast, symbols, symbol_to_node){
         var nn = doc2.documentElement.firstChild
         n.firstChild.textContent += nn.firstChild.textContent;
         for(nn = nn.nextSibling; nn; nn = nn.nextSibling){
-            n.parentNode.insertBefore(nn.cloneNode(true),null); 
+            n.parentNode.insertBefore(nn.cloneNode(true),null);
         }
     }
     var ensure_text_nodes = function(base){
@@ -202,9 +202,15 @@ AST.to_function = function(ast, functions){
 }
 
 AST.eval = function(ast, functions, parent){
+    if(ast.length == 1 && ast[0] == "blank"){
+        var elem = document.implementation.createDocument(null, "c");
+        elem.documentElement.innerHTML = "<e></e>";
+        return elem;
+    }
+
     ans = null;
     if(!functions["_default"]) functions["_default"] = function(name, args){ throw Error("Function not implemented: " + name + "(" + args + ")");}
-    
+
     var args = []
     for(var i = 0; i < ast[1].length; i++){
         if(Object.prototype.toString.call(ast[1][i]) === '[object Array]'){
@@ -217,7 +223,7 @@ AST.eval = function(ast, functions, parent){
     var ans = null;
     if(functions[ast[0]]) ans = functions[ast[0]](args, parent);
     else if(functions["_default"]) ans = functions["_default"](ast[0], args, parent);
-    
+
     return ans
 }
 

--- a/src/doc.js
+++ b/src/doc.js
@@ -100,6 +100,9 @@ Doc.prototype.import_latex = function(text, syms, s2n){
 }
 
 Doc.prototype.import_ast = function(ast, syms, s2n){
+    if(typeof tree == "string"){
+        tree = JSON.parse(tree);
+    }
     syms = syms || Symbols.symbols;
     s2n = s2n || Symbols.symbol_to_node;
     var doc = AST.to_xml(ast, syms, s2n);

--- a/src/doc.js
+++ b/src/doc.js
@@ -100,8 +100,8 @@ Doc.prototype.import_latex = function(text, syms, s2n){
 }
 
 Doc.prototype.import_ast = function(ast, syms, s2n){
-    if(typeof tree == "string"){
-        tree = JSON.parse(tree);
+    if(typeof ast == "string"){
+        ast = JSON.parse(ast);
     }
     syms = syms || Symbols.symbols;
     s2n = s2n || Symbols.symbol_to_node;

--- a/test/test.js
+++ b/test/test.js
@@ -706,7 +706,15 @@ var tests = [
 	"expected":"matrix(list(list((pi / 2),(x^2)),list(defintegral(1,2,squareroot(x),x),sin(x))))",
 	"run":function(g){
 	    Guppy("guppy1").import_syntax_tree(["matrix",[["list",[["list",[["fraction",[["var",["pi"]],["val",[2]]]],["exponential",[["var",["x"]],["val",[2]]]]]],["list",[["defintegral",[["val",[1]],["val",[2]],["squareroot",[["var",["x"]]]],["var",["x"]]]],["sin",[["var",["x"]]]]]]]]]]);
-	}
+    }
+    },
+    {
+	"description":"import_ast string with blank",
+	"type":"text",
+	"expected":"(1 / ())",
+	"run":function(g){
+	    Guppy("guppy1").import_syntax_tree("[\"fraction\",[[\"val\",[1]],[\"blank\"]]]")
+    }
     },
     {
 	"description":"Comparisons",
@@ -1060,7 +1068,7 @@ describe('Guppy',function(){
     beforeEach(function() {
 	pre_test();
     });
-    
+
     afterEach(function() {
 	post_test();
     });


### PR DESCRIPTION
When importing a syntax tree it can be given as a string to keep it more consistent - can now do `g1.import_syntax_tree(g1.syntax_tree());`

It can now also import syntax trees that contain a blank, such as a fraction where only the numerator is entered (`\frac{1}{...}`)

This means that you can do
`g1.engine.insert_doc(new Guppy.Doc(g1.syntax_tree(), "ast")); g1.activate();`
to duplicate the editor at the cursor.

For example type in `1/`, run the above command and the editor will contain `1/1/`. Although, when I was testing it, at times I was getting `Error: Undefined` but I think that was to do with something else. I'll have a look at that later.

Also came across issue #153 while working on this.