### PR TITLE
Auto bracket improvements

### DIFF
--- a/build/guppy.js
+++ b/build/guppy.js
@@ -4001,7 +4001,8 @@ var Guppy = (function () {
         var e0 = n.firstChild;
         var e1 = n.lastChild;
         var previous_sibling = n.parentNode.previousSibling;
-        if (previous_sibling && previous_sibling.nodeName == "e" && previous_sibling.textContent && !"+-".includes(previous_sibling.textContent.slice(-1))) {
+        if (previous_sibling && previous_sibling.nodeName == "e" && previous_sibling.textContent && "0123456789".includes(previous_sibling.textContent.slice(-1))) {
+            // there is no operator before the symbol
             return true;
         }
         if (n.childElementCount == 3 && e0.firstChild.textContent == "" && e1.firstChild.textContent == "") {

--- a/build/guppy.js
+++ b/build/guppy.js
@@ -4000,6 +4000,10 @@ var Guppy = (function () {
     Doc.prototype.auto_bracket = function (n) {
         var e0 = n.firstChild;
         var e1 = n.lastChild;
+        var previous_sibling = n.parentNode.previousSibling;
+        if (previous_sibling && previous_sibling.nodeName == "e" && previous_sibling.textContent && !"+-".includes(previous_sibling.textContent.slice(-1))) {
+            return true;
+        }
         if (n.childElementCount == 3 && e0.firstChild.textContent == "" && e1.firstChild.textContent == "") {
             // single f child, all e children empty
             var f = e0.nextSibling;
@@ -4177,99 +4181,99 @@ var Guppy = (function () {
     };
 
     var Keyboard = function Keyboard() {
-    			this.is_mouse_down = false;
+    				this.is_mouse_down = false;
 
-    			/* keyboard behaviour definitions */
+    				/* keyboard behaviour definitions */
 
-    			// keys aside from 0-9,a-z,A-Z
-    			this.k_chars = {
-    						"+": "+",
-    						"-": "-",
-    						"*": "*",
-    						".": "."
-    			};
-    			this.k_text = {
-    						"/": "/",
-    						"*": "*",
-    						"(": "(",
-    						")": ")",
-    						"<": "<",
-    						">": ">",
-    						"|": "|",
-    						"!": "!",
-    						",": ",",
-    						".": ".",
-    						";": ";",
-    						"=": "=",
-    						"[": "[",
-    						"]": "]",
-    						"@": "@",
-    						"'": "'",
-    						"`": "`",
-    						":": ":",
-    						"\"": "\"",
-    						"?": "?",
-    						"space": " "
-    			};
-    			this.k_controls = {
-    						"up": "up",
-    						"down": "down",
-    						"right": "right",
-    						"left": "left",
-    						"alt+k": "up",
-    						"alt+j": "down",
-    						"alt+l": "right",
-    						"alt+h": "left",
-    						"space": "spacebar",
-    						"home": "home",
-    						"end": "end",
-    						"backspace": "backspace",
-    						"del": "delete_key",
-    						"mod+a": "sel_all",
-    						"mod+c": "sel_copy",
-    						"mod+x": "sel_cut",
-    						"mod+v": "sel_paste",
-    						"mod+z": "undo",
-    						"mod+y": "redo",
-    						"enter": "done",
-    						"mod+shift+right": "list_extend_copy_right",
-    						"mod+shift+left": "list_extend_copy_left",
-    						",": "list_extend_right",
-    						";": "list_extend_down",
-    						"mod+right": "list_extend_right",
-    						"mod+left": "list_extend_left",
-    						"mod+up": "list_extend_up",
-    						"mod+down": "list_extend_down",
-    						"mod+shift+up": "list_extend_copy_up",
-    						"mod+shift+down": "list_extend_copy_down",
-    						"mod+backspace": "list_remove",
-    						"mod+shift+backspace": "list_remove_row",
-    						"shift+left": "sel_left",
-    						"shift+right": "sel_right",
-    						")": "right_paren",
-    						"\\": "backslash",
-    						"tab": "tab"
-    			};
+    				// keys aside from 0-9,a-z,A-Z
+    				this.k_chars = {
+    								"+": "+",
+    								"-": "-",
+    								"*": "*",
+    								".": "."
+    				};
+    				this.k_text = {
+    								"/": "/",
+    								"*": "*",
+    								"(": "(",
+    								")": ")",
+    								"<": "<",
+    								">": ">",
+    								"|": "|",
+    								"!": "!",
+    								",": ",",
+    								".": ".",
+    								";": ";",
+    								"=": "=",
+    								"[": "[",
+    								"]": "]",
+    								"@": "@",
+    								"'": "'",
+    								"`": "`",
+    								":": ":",
+    								"\"": "\"",
+    								"?": "?",
+    								"space": " "
+    				};
+    				this.k_controls = {
+    								"up": "up",
+    								"down": "down",
+    								"right": "right",
+    								"left": "left",
+    								"alt+k": "up",
+    								"alt+j": "down",
+    								"alt+l": "right",
+    								"alt+h": "left",
+    								"space": "spacebar",
+    								"home": "home",
+    								"end": "end",
+    								"backspace": "backspace",
+    								"del": "delete_key",
+    								"mod+a": "sel_all",
+    								"mod+c": "sel_copy",
+    								"mod+x": "sel_cut",
+    								"mod+v": "sel_paste",
+    								"mod+z": "undo",
+    								"mod+y": "redo",
+    								"enter": "done",
+    								"mod+shift+right": "list_extend_copy_right",
+    								"mod+shift+left": "list_extend_copy_left",
+    								",": "list_extend_right",
+    								";": "list_extend_down",
+    								"mod+right": "list_extend_right",
+    								"mod+left": "list_extend_left",
+    								"mod+up": "list_extend_up",
+    								"mod+down": "list_extend_down",
+    								"mod+shift+up": "list_extend_copy_up",
+    								"mod+shift+down": "list_extend_copy_down",
+    								"mod+backspace": "list_remove",
+    								"mod+shift+backspace": "list_remove_row",
+    								"shift+left": "sel_left",
+    								"shift+right": "sel_right",
+    								")": "right_paren",
+    								"\\": "backslash",
+    								"tab": "tab"
+    				};
 
-    			// Will populate keyboard shortcuts for symbols from symbol files
-    			this.k_syms = {};
+    				// Will populate keyboard shortcuts for symbols from symbol files
+    				this.k_syms = {};
 
-    			this.k_raw = "mod+space";
+    				this.k_raw = "mod+space";
 
-    			var i = 0;
+    				var i = 0;
 
-    			// letters
+    				// letters
 
-    			for (i = 65; i <= 90; i++) {
-    						this.k_chars[String.fromCharCode(i).toLowerCase()] = String.fromCharCode(i).toLowerCase();
-    						this.k_chars['shift+' + String.fromCharCode(i).toLowerCase()] = String.fromCharCode(i).toUpperCase();
-    			}
+    				for (i = 65; i <= 90; i++) {
+    								this.k_chars[String.fromCharCode(i).toLowerCase()] = String.fromCharCode(i).toLowerCase();
+    								this.k_chars['shift+' + String.fromCharCode(i).toLowerCase()] = String.fromCharCode(i).toUpperCase();
+    				}
 
-    			// numbers
+    				// numbers
 
-    			for (i = 48; i <= 57; i++) {
-    						this.k_chars[String.fromCharCode(i)] = String.fromCharCode(i);
-    			}
+    				for (i = 48; i <= 57; i++) {
+    								this.k_chars[String.fromCharCode(i)] = String.fromCharCode(i);
+    				}
     };
 
     var Settings = {};

--- a/src/doc.js
+++ b/src/doc.js
@@ -194,7 +194,7 @@ Doc.prototype.auto_bracket = function(n){
     var e0 = n.firstChild;
     var e1 = n.lastChild;
     var previous_sibling = n.parentNode.previousSibling;
-    if(previous_sibling && previous_sibling.nodeName == "e" && previous_sibling.textContent && !"+-".includes(previous_sibling.textContent.slice(-1))){ // there is no operator before the symbol
+    if(previous_sibling && previous_sibling.nodeName == "e" && previous_sibling.textContent && "0123456789".includes(previous_sibling.textContent.slice(-1))){ // there is no operator before the symbol
         return true;
     }
     if(n.childElementCount == 3 && e0.firstChild.textContent == "" && e1.firstChild.textContent == ""){ // single f child, all e children empty

--- a/src/doc.js
+++ b/src/doc.js
@@ -193,6 +193,10 @@ Doc.prototype.set_content = function(xml_data){
 Doc.prototype.auto_bracket = function(n){
     var e0 = n.firstChild;
     var e1 = n.lastChild;
+    var previous_sibling = n.parentNode.previousSibling;
+    if(previous_sibling && previous_sibling.nodeName == "e" && previous_sibling.textContent && !"+-".includes(previous_sibling.textContent.slice(-1))){ // there is no operator before the symbol
+        return true;
+    }
     if(n.childElementCount == 3 && e0.firstChild.textContent == "" && e1.firstChild.textContent == ""){ // single f child, all e children empty
         var f = e0.nextSibling;
     var cs = 0;


### PR DESCRIPTION
Now brackets are shown when the previous character is a number.
E.g. Typing `12(12)^2` now explicitly renders the brackets but `ab^2`, `12+12^2` or `12*12^2` does not.

This fixes #135 but when importing the syntax tree, the multiplication becomes hidden.
E.g. `3*10^8` becomes `3(10)^8`. I guess this is expected as the syntax tree does not contain this information. Maybe there should be another symbol, like `mul_implicit` to differentiate the two?