### PR TITLE
Argument RegExp Supports

### DIFF
--- a/src/engine.js
+++ b/src/engine.js
@@ -330,6 +330,11 @@ Engine.prototype.template_to_node = function(tmpl_name, content, name, tmpl_args
     Should match one of the keys in the symbols JSON object
 */
 Engine.prototype.insert_symbol = function(sym_name,sym_args){
+    if (this.current.parentNode.hasAttribute("regexp")) {
+      this.right();
+      this.insert_symbol(sym_name);
+      return;
+    }
     var s = sym_args ? Symbols.make_template_symbol(sym_name, sym_args.name, sym_args) : this.symbols[sym_name];
     if(s.attrs && this.is_blacklisted(s.attrs.type)){
         return false;

--- a/src/engine.js
+++ b/src/engine.js
@@ -480,6 +480,17 @@ Engine.prototype.make_e = function(text){
     @param {string} s - The string to insert.
 */
 Engine.prototype.insert_string = function(s){
+    if (this.current.parentNode.hasAttribute("regex")) {
+        var regexp = RegExp(this.current.parentNode.getAttribute("regex"));
+        var argu = this.current;
+        var siblingString = argu.parentNode.firstChild.textContent;
+        var newStringArgument = siblingString + s;
+        if (!newStringArgument.match(regexp)) {
+          this.right();
+          this.insert_string(s);
+          return;
+        }
+    }
     var self = this;
     if(this.sel_status != Engine.SEL_NONE){
         this.sel_delete();

--- a/src/guppy.js
+++ b/src/guppy.js
@@ -217,6 +217,8 @@ Guppy.make_button = function(cls, parent, cb){
     "math" (the default)
     @param {string} [symbol.args.is_bracket="no"] - Set to "yes" if
     the symbol is itself a bracket/parenthesis equivalent.
+    @param {string} [symbol.args.regexp] - Set to limit String Arguments'
+    expression with regexp
     @param {string} [template] - The name of the template to use
 */
 Guppy.add_global_symbol = function(name, symbol, template){


### PR DESCRIPTION
AS-IS:
Now, when creating a symbol, there is no way to limit the argument. For example, when adding a symbol corresponding to \dot in the latex syntax, if you want to receive only one number as the argument, you need to implement a method to limit arguments at the app layer instead of the library layer.

TO-DO:
When creating a symbol, developers can add `symbol.args.regexp` to limit arguments with regexp

LIMITATION:
~I think it is not proper to implement regexp to the symbol insertion, so it is limited only to string insertion.~
Symbol Insertions are considered not to match regexp automatically